### PR TITLE
Support {N} Android 5.4 version

### DIFF
--- a/demo/nsconfig.json
+++ b/demo/nsconfig.json
@@ -1,0 +1,3 @@
+{
+	"useLegacyWorkflow": true
+}

--- a/demo/package.json
+++ b/demo/package.json
@@ -16,10 +16,10 @@
       }
     },
     "tns-ios": {
-      "version": "4.1.0"
+      "version": "5.4.0"
     },
     "tns-android": {
-      "version": "4.1.1"
+      "version": "5.4.0"
     }
   },
   "dependencies": {
@@ -32,7 +32,7 @@
     "nativescript-cordova-support": "file:../src",
     "nativescript-theme-core": "~1.0.4",
     "phonegap-plugin-barcodescanner": "https://github.com/mbektchiev/phonegap-plugin-barcodescanner/archive/7.1.2-fixed.tar.gz",
-    "tns-core-modules": "^4.1.0"
+    "tns-core-modules": "^5.4.1"
   },
   "devDependencies": {
     "babel-traverse": "6.4.5",

--- a/src/.npmrc
+++ b/src/.npmrc
@@ -1,0 +1,2 @@
+package-lock = false
+bin-links = false

--- a/src/lib/hooks/before-prepare.js
+++ b/src/lib/hooks/before-prepare.js
@@ -183,6 +183,7 @@ function prepareForAddingCordovaPlugins(platform, pluginPackageName, platformDir
         fs.writeFileSync(path.join(mainDirectory, ANDROID_MANIFEST_FILE_NAME), `<?xml version='1.0' encoding='utf-8'?>
 <manifest android:hardwareAccelerated="true" android:versionCode="10000" android:versionName="1.0.0" package="${pluginPackageName}" xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
+        <activity/>
     </application>
 
 </manifest>
@@ -232,6 +233,10 @@ function processCordovaProject(cordovaProjectDir, platform, pluginDataObjects, i
                     break;
                 case "java":
                     fse.copySync(fullSrcPath, fullDestPath, { filter: (src, dest) => src.indexOf(idStringComponent) === -1 });
+                    break;
+                case "AndroidManifest.xml":
+                    const androidManifestContent = fse.readFileSync(fullSrcPath).toString();
+                    fse.writeFileSync(fullDestPath, androidManifestContent.replace('<activity android:launchMode="singleTop" />', ''));
                     break;
                 default:
                     fse.copySync(fullSrcPath, fullDestPath);

--- a/src/lib/hooks/before-prepare.js
+++ b/src/lib/hooks/before-prepare.js
@@ -352,6 +352,11 @@ ext.cdvMinSdkVersion = null
 ${pluginGradleExtensionsSection}
 
 dependencies {
+    def supportVer = "28.0.0"
+    if (project.hasProperty("supportVersion")) {
+        supportVer = supportVersion
+    }
+
     implementation fileTree(dir: '${LIBS_DIRECTORY_NAME}', include: '*.jar')
     ${subProjectDependenciesSection}
 }
@@ -389,8 +394,8 @@ function getStringBetween(str, start, end) {
 
 function getUnifiedAppCompatSupportContent(originalContent) {
     return originalContent
-        .replace(/(com.android.support:appcompat-v7:).*?(['"])/g, "$1$supportVersion$2")
-        .replace(/(com.android.support:support-v4:).*?(['"])/g, "$1$supportVersion$2");
+        .replace(/(com.android.support:appcompat-v7:).*?(['"])/g, "$1$supportVer$2")
+        .replace(/(com.android.support:support-v4:).*?(['"])/g, "$1$supportVer$2");
 }
 
 function getAndroidAppDir(platformsDirectory) {


### PR DESCRIPTION
* Add activity to the AndroidManifest.  …
  * If the activity tag is not present in the AndroidManifest Cordova prepare will throw `UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'attrib' of null`.
* Ensure that the support version is present in the Gradle project
* Update demo project.

### Note that the webpack workflow is not supported with this plugin